### PR TITLE
Draft: Désactiver la fonctionnalité "impersonation"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # NB: This is the default location for the Dockerfile
 FROM quay.io/keycloak/keycloak:19.0
 COPY ./themes/inclusion-connect/ /opt/keycloak/themes/inclusion-connect/
+ENV KC_FEATURES_DISABLED=impersonation
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
 # The spi-connections-jpa-default-migration-strategy option is here
 # to upgrade the database from v16.1.1

--- a/docker/dev/keycloak/Dockerfile
+++ b/docker/dev/keycloak/Dockerfile
@@ -3,5 +3,6 @@ FROM quay.io/keycloak/keycloak:19.0
 # theme is mounted with docker file so that we don't have to create a new docker image
 # for every change in the theme.
 
+ENV KC_FEATURES_DISABLED=impersonation
 # Use start-dev command instead of start
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev"]


### PR DESCRIPTION
Ce commit ne fonctionne pas. J'ai ouvert une issue sur leur dépôt GitHub : https://github.com/keycloak/keycloak/issues/13688

C'est bon : il suffit d'attendre la prochaine release (après 19.0.1).
Avec l'image docker nightly, ça fonctionne.