### PR TITLE
Formater les durée dans les emails

### DIFF
--- a/themes/inclusion-connect/email/messages/messages_fr.properties
+++ b/themes/inclusion-connect/email/messages/messages_fr.properties
@@ -1,13 +1,13 @@
 # encoding: UTF-8
 emailVerificationSubject=Vérification de l''adresse e-mail
-emailVerificationBody=Une demande de création de compte a été effectuée avec votre adresse e-mail. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous afin de vérifier votre adresse e-mail \n\n{0}\n\nCe lien expire dans {1} minutes.\n\nSinon, veuillez ignorer ce message.
-emailVerificationBodyHtml=<p>Une demande de création de compte a été effectuée avec votre adresse e-mail. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous afin de vérifier votre adresse e-mail</p><p><a href="{0}" rel="notrack">Lien pour vérifier votre adresse e-mail</a></p><p>Ce lien expire dans {1} minutes.</p><p>Sinon, veuillez ignorer ce message.</p>
+emailVerificationBody=Une demande de création de compte a été effectuée avec votre adresse e-mail. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous afin de vérifier votre adresse e-mail \n\n{0}\n\nCe lien expire dans {3}.\n\nSinon, veuillez ignorer ce message.
+emailVerificationBodyHtml=<p>Une demande de création de compte a été effectuée avec votre adresse e-mail. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous afin de vérifier votre adresse e-mail</p><p><a href="{0}" rel="notrack">Lien pour vérifier votre adresse e-mail</a></p><p>Ce lien expire dans {3}.</p><p>Sinon, veuillez ignorer ce message.</p>
 passwordResetSubject=Réinitialiser le mot de passe
-passwordResetBody=Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.\n\n{0}\n\nCe lien expire dans {1} minutes.\n\nSinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
-passwordResetBodyHtml=<p>Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.</p><p><a href="{0}" rel="notrack">Lien pour réinitialiser votre mot de passe</a></p><p>Ce lien expire dans {1} minutes.</p><p>Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.</p>
+passwordResetBody=Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.\n\n{0}\n\nCe lien expire dans {3}.\n\nSinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
+passwordResetBodyHtml=<p>Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l''origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.</p><p><a href="{0}" rel="notrack">Lien pour réinitialiser votre mot de passe</a></p><p>Ce lien expire dans {3}.</p><p>Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.</p>
 executeActionsSubject=Mettre à jour votre compte
-executeActionsBody=Votre administrateur vient de demander une mise à jour de votre compte. Veuillez cliquer sur le lien ci-dessous afin de commencer le processus.\n\n{0}\n\nCe lien expire dans {1} minutes.\n\nSi vous n''êtes pas à l''origine de cette requête, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
-executeActionsBodyHtml=<p>Votre administrateur vient de demander une mise à jour de votre compte. Veuillez cliquer sur le lien ci-dessous afin de commencer le processus.</p><p><a href="{0}" rel="notrack">Lien pour mettre à jour votre compte.</a></p><p>Ce lien expire dans {1} minutes.</p><p>Si vous n''êtes pas à l''origine de cette requête, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.</p>
+executeActionsBody=Votre administrateur vient de demander une mise à jour de votre compte. Veuillez cliquer sur le lien ci-dessous afin de commencer le processus.\n\n{0}\n\nCe lien expire dans {4}.\n\nSi vous n''êtes pas à l''origine de cette requête, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
+executeActionsBodyHtml=<p>Votre administrateur vient de demander une mise à jour de votre compte. Veuillez cliquer sur le lien ci-dessous afin de commencer le processus.</p><p><a href="{0}" rel="notrack">Lien pour mettre à jour votre compte.</a></p><p>Ce lien expire dans {4}.</p><p>Si vous n''êtes pas à l''origine de cette requête, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.</p>
 eventLoginErrorSubject=Erreur de connexion
 eventLoginErrorBody=Une tentative de connexion a été détectée sur votre compte depuis {1}. Si vous n''êtes pas à l''origine de cette requête, veuillez contacter votre administrateur.
 eventLoginErrorBodyHtml=<p>Une tentative de connexion a été détectée sur votre compte depuis {1}. Si vous n''êtes pas à l''origine de cette requête, veuillez contacter votre administrateur.</p>
@@ -25,3 +25,12 @@ greeting=Bonjour,\n\n
 greetingHtml=<p>Bonjour,</p>
 closing=L''équipe d''inclusion connect
 closingHtml=<p>L''équipe d''inclusion connect</p>
+
+linkExpirationFormatter.timePeriodUnit.seconds=secondes
+linkExpirationFormatter.timePeriodUnit.seconds.1=seconde
+linkExpirationFormatter.timePeriodUnit.minutes=minutes
+linkExpirationFormatter.timePeriodUnit.minutes.1=minute
+linkExpirationFormatter.timePeriodUnit.hours=heures
+linkExpirationFormatter.timePeriodUnit.hours.1=heure
+linkExpirationFormatter.timePeriodUnit.days=jours
+linkExpirationFormatter.timePeriodUnit.days.1=jour


### PR DESCRIPTION
Depuis qu'on a passé la durée de vie des emails à 24h dans les configurations de keycloak, on reçoit des emails avec 'ce lien expirera dans 1440 minutes' ce qui n'est pas top.

Avec cette PR on affichera "dans 1 jour" (pas trouvé comment s'arrêter à une durée en heures)