### PR TITLE
Alaurent/account migration improvments

### DIFF
--- a/docs/openid_connect.md
+++ b/docs/openid_connect.md
@@ -113,6 +113,10 @@ Les paramètres sont les suivants :
 L'Utilisateur pourra se connecter s'il possède un compte, ou créer un compte en suivant le lien "Se créer un compte".
 
 Il est possible d'utiliser l'endpoint _Registration_ (avec les mêmes paramètres) pour que l'utilisateur arrive directement sur cette seconde page.
+Cet endpoint possède deux paramètres de plus pour faciliter la migration de comptes :
+- **firstname**: permet de pré-remplir le prénom de l'utilisateur
+- **lastname**: permet de pré-remplir le nom de famille de l'utilisateur
+Sur cette page, les champs pré-remplis ne sont pas modifiables. Cela permet de s'assurer qu'un utilisateur existant d'une plateforme qui migre son compte à Incluion Connect ne change pas son email (ce qui empêcherait la plateforme de le reconnaitre).
 
 Note : il est possible d'ajouter des paramètres supplémentaires via la redirect_uri, à passer après ? sous la forme clé=valeur. Ils seront renvoyés tels quels lors du retour vers le FS.
 

--- a/docs/openid_connect.md
+++ b/docs/openid_connect.md
@@ -54,6 +54,7 @@ Le format des urls est le suivant :
 | Token         | https://{hostname}/realms/{realm-name}/protocol/openid-connect/token         |
 | UserInfo      | https://{hostname}/realms/{realm-name}/protocol/openid-connect/userinfo      |
 | Logout        | https://{hostname}/realms/{realm-name}/protocol/openid-connect/logout        |
+| Login-Reset   | https://{hostname}/realms/{realm-name}/login-actions/reset-credentials       |
 
 Contactez l'équipe du projet pour obtenir les variables de production et de recette.
 
@@ -257,3 +258,29 @@ qui sera ensuite redirigé vers l'url passée avec le paramètre **post_logout_r
 
 Si le `STATE` et/ou l'`ID_TOKEN` ne sont pas disponibles, il est possible de déconnecter l'utilisateur avec une redirection  vers `https://{hostname}/realms/{realm-name}/protocol/openid-connect/logout?client_id=<CLIENT_ID>&post_logout_redirect_uri=<FS_URL>%2F<POST_LOGOUT_REDIRECT_URI>`.
 Dans ce cas, l'utilisateur devra confirmer sa volonté de se deconnecter d'Inclusion Connect et sera ensuite redirigé vers l'url passée avec le paramètre **post_logout_redirect_uri**.
+
+### 6) Ré-initialisation de mots de passe
+
+On accède généralement à cette page en cliquant sur "Mot de passe oublié" depuis la page de connexion.
+
+Cependant il est possible d'envoyer directement un utilisateur sur cette page, ce qui est utile notamment dans
+le cas où l'on a importé des utilisateurs d'une plateforme dans Inclusion Connect et où ils ne leur reste qu'à
+changer de mot de passe pour activer leur compte.
+
+Voici le fonctionnement dans ce cas.
+
+#### Description
+
+- Contexte : Le FS redirige l'utilisateur vers l'endpoint _Login-Reset_
+- Origine : FS (par exemple lien dans un email)
+- Cible : Inclusion Connect
+- Type d'appel : redirection navigateur
+
+#### Requête
+
+- URL : `https://{hostname}/realms/{realm-name}/login-actions/reset-credentials`
+- Méthode : POST
+
+Voici les arguments que l'on peut ajouter à l'url :
+- **email** : l'adresse email de l'utilisateur. Cela lui permet de ne pas re-saissir son email sur cette page
+et facilite donc l'activation de son compte.

--- a/themes/inclusion-connect/login/login-reset-password.ftl
+++ b/themes/inclusion-connect/login/login-reset-password.ftl
@@ -28,3 +28,10 @@
         </p>
     </#if>
 </@layout.registrationLayout>
+<script>
+    var sp = new URLSearchParams(window.location.search);
+    var email = sp.get('email');
+    if (email) {
+        document.getElementById("username").value = email;
+    }
+</script>

--- a/themes/inclusion-connect/login/register.ftl
+++ b/themes/inclusion-connect/login/register.ftl
@@ -2,10 +2,11 @@
 <@layout.registrationLayout displayInfo=true; section>
     <#if section = "header">
         <p class="fr-h5 fr-mb-0 service-from"></p>
-        <h1 class="fr-h1">Créer un compte</h1>
-        <p class="fr-text--lg fr-mb-3w">Créer un compte Inclusion Connect vous permettra d'utiliser le même identifiant et le même mot de passe pour plusieurs services.</p>
+        <h1 class="fr-h1 create">Créer un compte</h1>
+        <p class="fr-text--lg fr-mb-3w create">Créer un compte Inclusion Connect vous permettra d'utiliser le même identifiant et le même mot de passe pour plusieurs services.</p>
     <#elseif section = "form">
         <form id="kc-register-form" action="${url.registrationAction}" method="post">
+            <p class="fr-text--lg fr-mb-3w" id="activation-description" style="display:none;"></p>
             <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('lastName',properties.kcFormGroupErrorClass!)}">
                 <label for="lastName" class="${properties.kcLabelClass!}">${msg("lastName")}</label>
                 <input type="text" id="lastName" class="${properties.kcInputClass!} ${messagesPerField.printIfExists('lastName',properties.kcInputErrorClass!)}" name="lastName" value="${(register.formData.lastName!'')}" />
@@ -77,3 +78,37 @@
         </p>
     </#if>
 </@layout.registrationLayout>
+<script>
+    var sp = new URLSearchParams(window.location.search);
+    var firstName = sp.get('firstname');
+    var firstNameEl = document.getElementById("firstName")
+    if (firstName) {
+        firstNameEl.value = firstName;
+        firstNameEl.readOnly = true;
+    }
+
+    var lastName = sp.get('lastname');
+    var lastNameEl = document.getElementById("lastName")
+    if (lastName) {
+        lastNameEl.value = lastName;
+        lastNameEl.readOnly = true;
+    }
+
+    var emailEl = document.getElementById("email")
+    if (emailEl.value) {
+        emailEl.readOnly = true;
+    }
+
+    if (firstName && lastName && emailEl.value) {
+        var createToReplace = document.getElementsByClassName("create");
+        Array.prototype.forEach.call(createToReplace, function(el) {
+            el.innerHTML = el.innerHTML.replace("Créer un", "Activer votre");
+        })
+        var accountDescriptionEl = document.getElementById("activation-description");
+        firstNameEl.parentNode.style.display = 'none';
+        lastNameEl.parentNode.style.display = 'none';
+        emailEl.parentNode.style.display = 'none';
+        accountDescriptionEl.style.display = 'block';
+        accountDescriptionEl.innerHTML = lastName + " " + firstName + " (" + emailEl.value + ")"
+    }
+</script>


### PR DESCRIPTION
- Permettre d'envoyer un utilisateur directement sur la page de ré-initialisation de mot de passe en ayant l'email de pré-renseigné (pour les utilisateurs importés via script notamment)
- Permettre d'envoyer un utilisateur directement sur la page de création de compte en ayant les champs email, nom et prénom de renseigné et en les cachant pour simplifier le parcours d'"activation" de compte Inclusion Connect
![Screenshot from 2023-01-06 15-21-42](https://user-images.githubusercontent.com/7632730/211030664-4d2abcc0-0b7a-4a2f-a415-07073ef3d3d8.png)
- Bloquer la validation d'email depuis un autre navigateur et expliquer à l'utilisateur qu'il doit faire la confirmation depuis le même navigateur.
![Screenshot from 2023-01-06 15-06-37](https://user-images.githubusercontent.com/7632730/211029583-3f6da2d9-ba18-493c-b6dd-73f95444df91.png)
