### PR TITLE
Amélioration du message de re-initialisation de mot de passe

### DIFF
--- a/themes/inclusion-connect/login/messages/messages_fr.properties
+++ b/themes/inclusion-connect/login/messages/messages_fr.properties
@@ -187,7 +187,7 @@ resetPasswordMessage=Vous devez changer votre mot de passe.
 verifyEmailMessage=Vous devez vérifier votre adresse e-mail pour activer votre compte.
 linkIdpMessage=Vous devez vérifier votre adresse e-mail pour lier votre compte avec {0}.
 
-emailSentMessage=Vous devriez recevoir rapidement un courriel avec de plus amples instructions.
+emailSentMessage=Si un compte existe avec cette adresse e-mail, vous recevrez un email contenant des instructions pour réinitialiser votre mot de passe.
 emailSendErrorMessage=<p style="color:red;">Erreur lors de l''envoi du courriel, veuillez essayer plus tard.</p>
 
 accountUpdatedMessage=Votre compte a été mis à jour.


### PR DESCRIPTION
Nous ne voulons pas dire quand un compte existe car c'est un problème de sécurité, mais nous pouvons indiquer à l'utilisateur qu'il ne recevra pas d'e-mail s'il n'a pas de compte.